### PR TITLE
Don't include iteration names in project directory names anymore

### DIFF
--- a/gradle-functional/src/main/groovy/net/neoforged/trainingwheels/gradle/functional/BuilderBasedTestSpecification.groovy
+++ b/gradle-functional/src/main/groovy/net/neoforged/trainingwheels/gradle/functional/BuilderBasedTestSpecification.groovy
@@ -39,7 +39,8 @@ abstract class BuilderBasedTestSpecification extends Specification {
     def setup() {
         configurePluginUnderTest()
 
-        this.projectDirectory = new File(getTestTempDirectory(), specificationContext.currentIteration.displayName)
+        // The @TempDir is already per-test, unless explicitly @Shared
+        this.projectDirectory = tempDir
         this.registeredRuntimesAreConfigured = true
         runtimes.values().forEach {runtime -> {
             final Runtime root = this.roots.get(runtime)


### PR DESCRIPTION
Do not append the iteration display name to the project directory, since it may either 1) exceed the MAX_PATH limit on Windows, or 2) include characters not allowed in file-system paths (i.e. ':' on Windows).

Including the name also doesn't seem to be necessary since the `@TempDir` that is used as the parent directory is already per-iteration.